### PR TITLE
Rewrite "orsh_read_command()" function

### DIFF
--- a/orsh_read_command.c
+++ b/orsh_read_command.c
@@ -5,5 +5,9 @@ char *orsh_read_command(void)
    char *buffer;
    size_t n;
    getline(&buffer, &n, stdin);
+   if(ferror(stdin)) {
+	   fprintf(stderr, "Orsh : getline() failed!\n");
+	   exit(EXIT_FAILURE);
+   }
    return buffer;
 }

--- a/orsh_read_command.c
+++ b/orsh_read_command.c
@@ -9,5 +9,6 @@ char *orsh_read_command(void)
 	   fprintf(stderr, "Orsh : getline() failed!\n");
 	   exit(EXIT_FAILURE);
    }
+   if(feof(stdin)) buffer = strdup("exit");
    return buffer;
 }

--- a/orsh_read_command.c
+++ b/orsh_read_command.c
@@ -2,41 +2,8 @@
 
 char *orsh_read_command(void)
 {
-    int buffSize = orsh_command_bufferSize;
-    int position = 0;
-    char* buffer = (char *) malloc(sizeof(char) * buffSize);
-    int character;
-
-    if(buffer == NULL)
-    {
-        fprintf(stderr,"Orsh : memory allocation problem, quit and try again !\n");
-        exit(EXIT_FAILURE);
-    }
-
-    while(1)
-    {
-        character = getchar();
-        if(character == EOF || character == '\n')
-        {
-            buffer[position] = '\0'; // put the last character of the string to null to indicate the end of the string
-            return buffer;
-        }
-        else
-        {
-            buffer[position] = character;
-        }
-        position++;
-
-        // in case the user exceded the maximum buffer size we allocated , we reallocate again 
-        if(position >= buffSize)
-        {
-            buffSize*=2; // we double the size of the buffer
-            buffer = realloc(buffer,buffSize); 
-            if(buffer == NULL)
-            {
-                fprintf(stderr,"Orsh : Reallocation error , quit and try again!\n");
-                exit(EXIT_FAILURE);
-            }
-        }
-    }
+   char *buffer;
+   size_t n;
+   getline(&buffer, &n, stdin);
+   return buffer;
 }

--- a/orsh_read_command.h
+++ b/orsh_read_command.h
@@ -1,3 +1,4 @@
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #define orsh_command_bufferSize 512


### PR DESCRIPTION
my new function does the same thing except that it's a lot simpler and uses less memory